### PR TITLE
feat: add initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.idea/
+*.iml
+*.out
+*.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ go:
 before_install:
   - go get github.com/nbio/st
   - go get -u gopkg.in/Sirupsen/logrus.v0
-  - go get -u gopkg.in/vinxi/utils.v0
   - go get -u -v github.com/axw/gocov/gocov
   - go get -u -v github.com/mattn/goveralls
   - go get -u -v github.com/golang/lint/golint

--- a/README.md
+++ b/README.md
@@ -16,9 +16,45 @@ See [godoc](https://godoc.org/github.com/vinxi/log) reference.
 
 ## Example
 
-#### Basic logging
+#### Basic logging in middleware handlers
 
 ```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+
+  "gopkg.in/vinxi/log.v0"
+  "gopkg.in/vinxi/vinxi.v0"
+)
+
+const port = 3100
+
+func main() {
+  // Create a new vinxi proxy
+  vs := vinxi.NewServer(vinxi.ServerOptions{Port: port})
+
+  // Plugin multiple middlewares writting some logs
+  vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
+    log.Info("[%s] %s", r.Method, r.RequestURI)
+    h.ServeHTTP(w, r)
+  })
+
+  vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
+    log.Warnf("%s", "foo bar")
+    h.ServeHTTP(w, r)
+  })
+
+  // Target server to forward
+  vs.Forward("http://httpbin.org")
+
+  fmt.Printf("Server listening on port: %d\n", port)
+  err := vs.Listen()
+  if err != nil {
+    fmt.Errorf("Error: %s\n", err)
+  }
+}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 
   // Plugin multiple middlewares writting some logs
   vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
-    log.Info("[%s] %s", r.Method, r.RequestURI)
+    log.Infof("[%s] %s", r.Method, r.RequestURI)
     h.ServeHTTP(w, r)
   })
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,11 @@
+# Examples
+
+Run:
+```bash
+$ go run ./_examples/<name>/<file>.go
+```
+
+Example:
+```bash
+$ go run ./_examples/foo/bar.go
+```

--- a/_examples/basic/basic.go
+++ b/_examples/basic/basic.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/vinxi/log.v0"
+	"gopkg.in/vinxi/vinxi.v0"
+)
+
+const port = 3100
+
+func main() {
+	// Create a new vinxi proxy
+	vs := vinxi.NewServer(vinxi.ServerOptions{Port: port})
+
+	// Plugin multiple middlewares writting some logs
+	vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
+		log.Info("[%s] %s", r.Method, r.RequestURI)
+		h.ServeHTTP(w, r)
+	})
+
+	vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
+		log.Warnf("%s", "foo bar")
+		h.ServeHTTP(w, r)
+	})
+
+	// Target server to forward
+	vs.Forward("http://httpbin.org")
+
+	fmt.Printf("Server listening on port: %d\n", port)
+	err := vs.Listen()
+	if err != nil {
+		fmt.Errorf("Error: %s\n", err)
+	}
+}

--- a/_examples/basic/basic.go
+++ b/_examples/basic/basic.go
@@ -16,7 +16,7 @@ func main() {
 
 	// Plugin multiple middlewares writting some logs
 	vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
-		log.Info("[%s] %s", r.Method, r.RequestURI)
+		log.Infof("[%s] %s", r.Method, r.RequestURI)
 		h.ServeHTTP(w, r)
 	})
 

--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ import (
 // mu provides thread synchronization for the public singleton API.
 var mu = sync.Mutex{}
 
-// Logger represents the standard default Logrus based logger.
+// Logger represents the standard default built-in logger (equivalent to default Logrus logger).
 var Logger = log.New()
 
 // New creates a new Logrus based logger.

--- a/log.go
+++ b/log.go
@@ -1,0 +1,133 @@
+// Package log implements a featured and structured generic logger
+// interface designed to be used in core and third-party vinxi components.
+package log
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	log "gopkg.in/Sirupsen/logrus.v0"
+)
+
+// mu provides thread synchronization for the public singleton API.
+var mu = sync.Mutex{}
+
+// Logger represents the standard default Logrus based logger.
+var Logger = log.New()
+
+// New creates a new Logrus based logger.
+func New() *log.Logger {
+	return log.New()
+}
+
+// WithFields returns a new entry with `fields` set.
+func WithFields(fields log.Fields) *log.Entry {
+	return Logger.WithFields(fields)
+}
+
+// WithField returns a new entry with the `key` and `value` set.
+func WithField(key string, value interface{}) *log.Entry {
+	return Logger.WithField(key, value)
+}
+
+// WithError returns a new entry with the "error" set to `err`.
+func WithError(err error) *log.Entry {
+	return Logger.WithError(err)
+}
+
+// Debug level message.
+func Debug(msg string) {
+	Logger.Debug(msg)
+}
+
+// Info level message.
+func Info(msg string) {
+	Logger.Info(msg)
+}
+
+// Warn level message.
+func Warn(msg string) {
+	Logger.Warn(msg)
+}
+
+// Error level message.
+func Error(msg string) {
+	Logger.Error(msg)
+}
+
+// Fatal level message, followed by an exit.
+func Fatal(msg string) {
+	Logger.Fatal(msg)
+}
+
+// Debugf level formatted message.
+func Debugf(msg string, v ...interface{}) {
+	Logger.Debugf(msg, v...)
+}
+
+// Infof level formatted message.
+func Infof(msg string, v ...interface{}) {
+	Logger.Infof(msg, v...)
+}
+
+// Warnf level formatted message.
+func Warnf(msg string, v ...interface{}) {
+	Logger.Warnf(msg, v...)
+}
+
+// Errorf level formatted message.
+func Errorf(msg string, v ...interface{}) {
+	Logger.Errorf(msg, v...)
+}
+
+// Fatalf level formatted message, followed by an exit.
+func Fatalf(msg string, v ...interface{}) {
+	Logger.Fatalf(msg, v...)
+}
+
+// Trace returns a new entry with a Stop method to fire off
+// a corresponding completion log, useful with defer.
+func Trace(msg string) *log.Entry {
+	e := log.NewEntry(Logger)
+	e.Info(msg)
+	v := e.WithFields(e.Data)
+	v.Message = msg
+	v.Time = time.Now()
+	return v
+}
+
+// SetOutput sets the standard logger output.
+func SetOutput(out io.Writer) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Out = out
+}
+
+// SetFormatter sets the standard logger formatter.
+func SetFormatter(formatter log.Formatter) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Formatter = formatter
+}
+
+// SetLevel sets the standard logger level.
+func SetLevel(level log.Level) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Level = level
+}
+
+// GetLevel returns the standard logger level.
+func GetLevel() log.Level {
+	mu.Lock()
+	defer mu.Unlock()
+	return Logger.Level
+}
+
+// AddHook adds a hook to the standard logger hooks.
+func AddHook(hook log.Hook) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Hooks.Add(hook)
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,54 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nbio/st"
+	log "gopkg.in/Sirupsen/logrus.v0"
+)
+
+// Since current implementation acts just as proxy to
+// Logrus API, tests are not testing too much here.
+func TestLogger(t *testing.T) {
+	var buffer bytes.Buffer
+	SetOutput(&buffer)
+	SetLevel(log.DebugLevel)
+	SetFormatter(&log.TextFormatter{DisableColors: true, DisableTimestamp: true, DisableSorting: true})
+
+	Info("foo bar")
+	st.Expect(t, safeString(buffer), `level=info msg="foo bar"`)
+
+	buffer.Reset()
+	Infof("foo %s", "bar")
+	st.Expect(t, safeString(buffer), `level=info msg="foo bar"`)
+
+	buffer.Reset()
+	Error("foo bar")
+	st.Expect(t, safeString(buffer), `level=error msg="foo bar"`)
+
+	buffer.Reset()
+	Errorf("foo %s", "bar")
+	st.Expect(t, safeString(buffer), `level=error msg="foo bar"`)
+
+	buffer.Reset()
+	Warn("foo bar")
+	st.Expect(t, safeString(buffer), `level=warning msg="foo bar"`)
+
+	buffer.Reset()
+	Warnf("foo %s", "bar")
+	st.Expect(t, safeString(buffer), `level=warning msg="foo bar"`)
+
+	buffer.Reset()
+	Debug("foo bar")
+	st.Expect(t, safeString(buffer), `level=debug msg="foo bar"`)
+
+	buffer.Reset()
+	Debugf("foo %s", "bar")
+	st.Expect(t, safeString(buffer), `level=debug msg="foo bar"`)
+}
+
+func safeString(buf bytes.Buffer) string {
+	b := buf.Bytes()
+	return string(b[:len(b)-2])
+}


### PR DESCRIPTION
Basic logging layer that acts like an API proxy to Logrus API.

Provides a standard built-in Logger that has no side effects with the standard one provided by Logrus (as singleton).
